### PR TITLE
Support sending emails via ssl

### DIFF
--- a/server/dev-config.json
+++ b/server/dev-config.json
@@ -4,7 +4,8 @@
 		"host": "smtp.gmail.com",
 		"port": 587,
 		"email": "",
-		"password": ""
+		"password": "",
+        "sslEnabled": false
 	},
 	"databaseConfig": {
 		"jdbcUrl": "jdbc:mysql://127.0.0.1/paperbots",

--- a/server/src/main/java/io/paperbots/Config.java
+++ b/server/src/main/java/io/paperbots/Config.java
@@ -70,7 +70,7 @@ public class Config {
 		}
 		return new Config(System.getenv("PAPERBOTS_RELOAD_PWD"),
 			new EmailConfig(System.getenv("PAPERBOTS_EMAIL_HOST"), Integer.parseInt(System.getenv("PAPERBOTS_EMAIL_PORT")),
-				System.getenv("PAPERBOTS_EMAIL_ADDRESS"), System.getenv("PAPERBOTS_EMAIL_PWD")),
+				System.getenv("PAPERBOTS_EMAIL_ADDRESS"), System.getenv("PAPERBOTS_EMAIL_PWD"), Boolean.parseBoolean(System.getenv("PAPERBOTS_EMAIL_SSL"))),
 			new DatabaseConfig(System.getenv("PAPERBOTS_DB_JDBC_URL"), System.getenv("PAPERBOTS_DB_USER"), System.getenv("PAPERBOTS_DB_PWD")));
 	}
 
@@ -80,13 +80,15 @@ public class Config {
 		private final int port;
 		private final String email;
 		private final String password;
+		private final Boolean sslEnabled;
 
 		public EmailConfig (@JsonProperty("host") String host, @JsonProperty("port") Integer port, @JsonProperty("email") String email,
-			@JsonProperty("password") String password) {
+			@JsonProperty("password") String password, @JsonProperty("sslEnabled") Boolean sslEnabled) {
 			this.host = Optional.ofNullable(host).orElseThrow( () -> new IllegalArgumentException("SMTP host is missing."));
 			this.port = Optional.ofNullable(port).orElseThrow( () -> new IllegalArgumentException("SMTP port is missing."));
 			this.email = Optional.ofNullable(email).orElseThrow( () -> new IllegalArgumentException("Email address is missing."));
 			this.password = Optional.ofNullable(password).orElseThrow( () -> new IllegalArgumentException("Email password is missing."));
+			this.sslEnabled = sslEnabled;
 		}
 
 		public String getHost () {
@@ -103,6 +105,10 @@ public class Config {
 
 		public String getPassword () {
 			return password;
+		}
+
+		public Boolean getSslEnabled() {
+			return sslEnabled!=null?sslEnabled:false;
 		}
 	}
 

--- a/server/src/main/java/io/paperbots/Emails.java
+++ b/server/src/main/java/io/paperbots/Emails.java
@@ -12,6 +12,7 @@ import javax.mail.Transport;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 
+import com.esotericsoftware.minlog.Log;
 import io.paperbots.Config.EmailConfig;
 import io.paperbots.PaperbotsException.PaperbotsError;
 
@@ -30,6 +31,8 @@ public interface Emails {
 			props.put("mail.smtp.auth", "true");
 			props.put("mail.smtp.host", config.getHost()); // "smtp.gmail.com");
 			props.put("mail.smtp.port", config.getPort()); // "587");
+			props.put("mail.smtp.ssl.enable", config.getSslEnabled()); // off by default
+			props.put("mail.smtp.timeout", 10000);
 			this.session = Session.getInstance(props, new javax.mail.Authenticator() {
 				@Override
 				protected PasswordAuthentication getPasswordAuthentication () {
@@ -51,6 +54,7 @@ public interface Emails {
 				msg.setHeader("XPriority", "1");
 				Transport.send(msg);
 			} catch (MessagingException e) {
+				Log.error("Could not send email", e);
 				throw new PaperbotsException(PaperbotsError.CouldNotSendEmail, e);
 			}
 		}


### PR DESCRIPTION
When running a local deployment  I discovered that sending emails via ssl was not supported.
Also no emails were sent and the request never returned a result when connecting to a ssl secured smtp endpoint.
Therefore I set a 10s timeout in addition in case of a wrong configuration.